### PR TITLE
GP-1793: Add Bank Authorization Handler for Greenpeace Poland

### DIFF
--- a/CRM/Streetimport/Config.php
+++ b/CRM/Streetimport/Config.php
@@ -581,8 +581,11 @@ class CRM_Streetimport_Config {
    */
   public static function getDomains() {
     // TODO: refer to an option group
-    return array('GP'   => 'GP',
-                 'AIVL' => 'AIVL');
+    return [
+      'GP' => 'Greenpeace Austria',
+      'GPPL' => 'Greenpeace Poland',
+      'AIVL' => 'Amnesty International Flanders',
+    ];
   }
 
   /**

--- a/CRM/Streetimport/GP/Config.php
+++ b/CRM/Streetimport/GP/Config.php
@@ -154,7 +154,8 @@ class CRM_Streetimport_GP_Config extends CRM_Streetimport_Config {
     // TODO: use SEPA function
 
     // find the right start date
-    $buffer_days = 2; // TODO: more?
+    $creditor = CRM_Sepa_Logic_Settings::defaultCreditor();
+    $buffer_days = (int) CRM_Sepa_Logic_Settings::getSetting("pp_buffer_days") + (int) CRM_Sepa_Logic_Settings::getSetting("batching.FRST.notice", $creditor->id);
     $now                 = strtotime($now);
     $start_date          = strtotime($start_date);
     $earliest_start_date = strtotime("+{$buffer_days} day", $now);

--- a/CRM/Streetimport/GPPL/Config.php
+++ b/CRM/Streetimport/GPPL/Config.php
@@ -1,0 +1,160 @@
+<?php
+/*-------------------------------------------------------------+
+| Greenpeace Poland StreetImporter Record Handlers             |
+| Copyright (C) 2018 Greenpeace CEE                            |
+| Author: P. Figel (pfigel@greenpeace.org)                     |
+|         M. McAndrew (michaelmcandrew@thirdsectordesign.org)  |
+|         B. Endres (endres -at- systopia.de)                  |
+| http://www.systopia.de/                                      |
++--------------------------------------------------------------*/
+
+/**
+ * Class following Singleton pattern for specific extension configuration
+ */
+class CRM_Streetimport_GPPL_Config extends CRM_Streetimport_Config {
+  private $_activeMembershipStatuses;
+  private $_cancelledMembershipStatus;
+  private $_pausedMembershipStatus;
+
+  public function __construct() {
+    CRM_Streetimport_Config::__construct();
+  }
+
+  /**
+   * get a list (id => name) of the relevant employees
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function getEmployeeList() {
+    // get user list
+    $employees = parent::getEmployeeList();
+
+    // currently, everybody with an external ID starting with 'USER-' is a user
+    //  so we want to add those
+    $result = civicrm_api3('Contact', 'get', array(
+      'return'              => 'display_name,id',
+      'external_identifier' => array('LIKE' => "USER-%"),
+      'options'             => array('limit' => 0),
+    ));
+    foreach ($result['values'] as $contact_id => $contact) {
+      $employees[$contact['id']] = $contact['display_name'];
+    }
+
+    return $employees;
+  }
+
+  /**
+   * get the default set of handlers
+   *
+   * @return an array of handler instances
+   */
+  public function getHandlers($logger) {
+    return array(
+      new CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler($logger),
+    );
+  }
+
+  public function getActiveMembershipStatuses() {
+    if (is_null($this->_activeMembershipStatuses)) {
+      $result = civicrm_api3('MembershipStatus', 'get', array(
+        'is_current_member' => 1,
+        'return'            => 'id'));
+      $this->_activeMembershipStatuses = array();
+      foreach ($result['values'] as $status) {
+        $this->_activeMembershipStatuses[] = $status['id'];
+      }
+    }
+    return $this->_activeMembershipStatuses;
+  }
+
+  public function getCancelledMembershipStatus() {
+    if (is_null($this->_cancelledMembershipStatus)) {
+      $this->_cancelledMembershipStatus = civicrm_api3('MembershipStatus', 'getvalue', [
+        'return' => 'id',
+        'name' => 'Cancelled',
+      ]);
+    }
+    return $this->_cancelledMembershipStatus;
+  }
+
+  public function getPausedMembershipStatus() {
+    if (is_null($this->_pausedMembershipStatus)) {
+      $this->_pausedMembershipStatus = civicrm_api3('MembershipStatus', 'getvalue', [
+        'return' => 'id',
+        'name' => 'Paused',
+      ]);
+    }
+    return $this->_pausedMembershipStatus;
+  }
+
+  /**
+   * calculate the next valid cycle day
+   *
+   * @param $start_date
+   * @param $now
+   *
+   * @return int
+   * @throws \Exception
+   */
+  public function getNextCycleDay($start_date, $now) {
+    // TODO: use SEPA function
+
+    // find the right start date
+    $creditor = CRM_Sepa_Logic_Settings::defaultCreditor();
+    $buffer_days = (int) CRM_Sepa_Logic_Settings::getSetting("pp_buffer_days") + (int) CRM_Sepa_Logic_Settings::getSetting("batching.FRST.notice", $creditor->id);
+    $now                 = strtotime($now);
+    $start_date          = strtotime($start_date);
+    $earliest_start_date = strtotime("+{$buffer_days} day", $now);
+    if ($start_date < $earliest_start_date) {
+      $start_date = $earliest_start_date;
+    }
+
+    // now: find the next valid start day
+    $cycle_days = $this->getCycleDays();
+    $safety_counter = 32;
+    while (!in_array(date('j', $start_date), $cycle_days)) {
+      $start_date = strtotime('+ 1 day', $start_date);
+      $safety_counter -= 1;
+      if ($safety_counter == 0) {
+        throw new Exception("There's something wrong with the getNextCycleDay method.");
+      }
+    }
+    return (int) date('j', $start_date);
+  }
+
+  /**
+   * Get the list of allowed cycle days
+   *
+   * @return string
+   */
+  public function getCycleDays() {
+    return CRM_Sepa_Logic_Settings::getListSetting("cycledays", range(1, 28), $this->getCreditorID());
+  }
+
+  /**
+   * get the SEPA creditor ID to be used for all mandates
+   *
+   * @return int
+   */
+  public function getCreditorID() {
+    $default_creditor = CRM_Sepa_Logic_Settings::defaultCreditor();
+    if (!empty($default_creditor->id)) {
+      return $default_creditor->id;
+    }
+    else {
+      return 1;
+    }
+  }
+
+  /**
+   * Should processing of the whole file stop if no handler was found for a
+   * line?
+   *
+   * @return bool
+   */
+  public function stopProcessingIfNoHanderFound() {
+    return TRUE;
+  }
+
+}

--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
@@ -1,0 +1,305 @@
+<?php
+/*-------------------------------------------------------------+
+| Greenpeace Poland StreetImporter Record Handlers             |
+| Copyright (C) 2018 Greenpeace CEE                            |
+| Author: P. Figel (pfigel@greenpeace.org)                     |
++--------------------------------------------------------------*/
+
+/**
+ * Greenpeace Poland Bank Authorization Response Import
+ *
+ * @author Patrick Figel <pfigel@greenpeace.org>
+ * @license AGPL-3.0
+ */
+class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streetimport_RecordHandler {
+
+  const PATTERN = '#/AU(?P<date>\d{6})\.csv$#';
+
+  private $_date;
+  private $_fileMatches;
+  private $_cancellationReasons = [];
+
+  public function __construct($logger) {
+    parent::__construct($logger);
+    $this->_loadCancellationReasons();
+  }
+
+  /**
+   * @param array $record
+   * @param $sourceURI
+   *
+   * @return bool|null|true
+   */
+  public function canProcessRecord($record, $sourceURI) {
+    if (is_null($this->_fileMatches)) {
+      $this->_fileMatches = (bool) preg_match(self::PATTERN, $sourceURI, $matches);
+      if ($this->_fileMatches) {
+        $this->_date = $matches['date'];
+      }
+    }
+    return $this->_fileMatches;
+  }
+
+  /**
+   * @param array $record
+   * @param $sourceURI
+   *
+   * @return void
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function processRecord($record, $sourceURI) {
+    $config = CRM_Streetimport_Config::singleton();
+    $membership = civicrm_api3('Membership', 'get', [
+      'membership_id' => $record['membership_id'],
+    ]);
+    if ($membership['count'] == 0) {
+      $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), $config->translate('Membership not found'));
+      return;
+    }
+    $membership = reset($membership['values']);
+    $now = time();
+    try {
+      if ($record['response_code'] == '1') {
+        $this->_createActivity($record, $membership['id'], $membership['contact_id'], 'Contract_Authorization_Approved', $record['response_description'], $now);
+        // approved
+        if ($membership['status_id'] == $config->getPausedMembershipStatus()) {
+          $this->_resumeContract($membership['id'], $membership['contact_id'], $now);
+          $this->_resetMembershipStartDate($membership['id'], $now);
+          $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Restarted Membership'));
+        }
+        elseif ($membership['status_id'] == $config->getCancelledMembershipStatus()) {
+          if ($this->_shouldReviveContract($membership)) {
+            // approved + contract is cancelled with authorization reason
+            $this->_reviveContract($membership['id'], $now);
+            $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Revived Membership'));
+          }
+          else {
+            $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Ignoring, Membership is cancelled for unrelated reason'));
+          }
+        }
+        elseif (in_array($membership['status_id'], $config->getActiveMembershipStatuses())) {
+          $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Ignoring, Membership is already active'));
+        }
+        else {
+          $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), $config->translate('Membership is in an undefined state'));
+        }
+      }
+      else {
+        $this->_createActivity($record, $membership['id'], $membership['contact_id'], 'Contract_Authorization_Refused', $record['response_code'] . ' - ' . $record['response_description'], $now);
+        // refused
+        if ($membership['status_id'] == $config->getPausedMembershipStatus()) {
+          // this is slightly non-obvious. We need to resume the contract before
+          // we can actually cancel it.
+          $this->_resumeContract($membership['id'], $membership['contact_id'], $now);
+          $this->_runScheduledModifications($membership['id']);
+          $this->_cancelContract($membership['id'], $record['response_code'], $now);
+          $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Cancelled Membership'));
+        }
+        elseif ($membership['status_id'] == $config->getCancelledMembershipStatus()) {
+          $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Ignoring, Membership is already cancelled'));
+        }
+        elseif (in_array($membership['status_id'], $config->getActiveMembershipStatuses())) {
+          $this->_cancelContract($membership['id'], $record['response_code'], $now);
+          $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Cancelled Membership'));
+        }
+        else {
+          $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), $config->translate('Membership is in an undefined state (' . $membership['status_id'] . ')'));
+        }
+      }
+    }
+    catch (CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException $e) {
+      $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), 'Error: ' . $e->getMessage());
+      return;
+    }
+  }
+
+  /**
+   * @param string $sourceURI
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function finishProcessing($sourceURI) {
+    $this->_runScheduledModifications();
+  }
+
+  /**
+   * Run all scheduled membership modifications. Optionally limited to one
+   * membership via $membershipId
+   *
+   * @param null $membershipId
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function _runScheduledModifications($membershipId = NULL) {
+    $data = [];
+    if (!is_null($membershipId)) {
+      $data['id'] = $membershipId;
+    }
+    civicrm_api3('Contract', 'process_scheduled_modifications', $data);
+  }
+
+  /**
+   * Sets the start_date
+   *
+   * @param $membershipId
+   * @param $contactId
+   * @param $time
+   *
+   * @throws \CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException
+   */
+  private function _resumeContract($membershipId, $contactId, $time) {
+    $config = CRM_Streetimport_Config::singleton();
+    $activityParams = [
+      'activity_type_id' => 'Contract_Resumed',
+      'is_current_revision' => 1,
+      'is_deleted' => 0,
+      'source_record_id' => $membershipId,
+      'target_contact_id' => $contactId,
+      'activity_date_time' => ['>=' => date('YmdHis', $time)],
+      'status_id' => 'scheduled',
+    ];
+
+    try {
+      $activities = civicrm_api3('Activity', 'Get', $activityParams);
+      if ($activities['count'] > 1) {
+        // TODO: check if we need to handle this somehow. I think it's theoretically possible to schedule multiple pauses?
+        throw new CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException(
+          "Found multiple resume activities for membership {$membershipId}"
+        );
+      }
+
+      if ($activities['count'] < 1) {
+        throw new CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException(
+          "Found no resume activity for membership {$membershipId}"
+        );
+      }
+
+      $activity = reset($activities['values']);
+
+      $cycleDayFieldId = CRM_Contract_Utils::getCustomFieldId('contract_updates.ch_cycle_day');
+      $updateParams = [
+        'id' => $activity['id'],
+        'activity_date_time' => date('YmdHis', $time),
+        'status_id' => 'scheduled',
+        $cycleDayFieldId => $config->getNextCycleDay(date('Y-m-d H:i:s', $time), $time),
+      ];
+      civicrm_api3('Activity', 'Create', $updateParams);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      throw new CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException(
+        'API error: ' . $e->getMessage()
+      );
+    }
+  }
+
+  private function _resetMembershipStartDate($membershipId, $time) {
+    // TODO: should probably not reset start_date for memberships that are being reauthorized?
+    $updateParams = [
+      'id' => $membershipId,
+      'start_date' => date('Y-m-d', $time),
+    ];
+    civicrm_api3('Membership', 'Create', $updateParams);
+  }
+
+  /**
+   * Determines whether a membership should be revived if a positive
+   * authorization is received. This is currently only true if the cancellation
+   * reason was authorization-related.
+   *
+   * @param $membership
+   *
+   * @return bool
+   */
+  private function _shouldReviveContract($membership) {
+    $cancellationReasonFieldId = CRM_Contract_Utils::getCustomFieldId('membership_cancellation.membership_cancel_reason');
+
+    if (!empty($membership[$cancellationReasonFieldId]) && strncasecmp('AUTH', $membership[$cancellationReasonFieldId], 4) === 0) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function _reviveContract($membershipId, $time) {
+    $config = CRM_Streetimport_Config::singleton();
+    $reviveModification = array(
+      // TODO: do we need medium? Campaign?
+      'action' => 'revive',
+      'date' => date('Y-m-d H:i:s', $time),
+      'id' => $membershipId,
+      'membership_payment.cycle_day' => $config->getNextCycleDay(date('Y-m-d H:i:s', $time), $time),
+    );
+    civicrm_api3('Contract', 'Modify', $reviveModification);
+  }
+
+  private function _cancelContract($membershipId, $responseCode, $time) {
+    $reason = 'AUTH' . $responseCode;
+    $this->_ensureCancellationReasonExists($reason);
+    $cancelModification = array(
+      // TODO: do we need medium? Campaign?
+      'action' => 'cancel',
+      'id' => $membershipId,
+      'membership_cancellation.membership_cancel_reason' => $reason,
+      'date' => date('Y-m-d H:i:s', $time),
+    );
+    try {
+      civicrm_api3('Contract', 'Modify', $cancelModification);
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      throw new CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException(
+        'API error: ' . $e->getMessage()
+      );
+    }
+  }
+
+  private function _loadCancellationReasons() {
+    $results = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'contract_cancel_reason']);
+    foreach ($results['values'] as $result) {
+      $this->_cancellationReasons[] = $result['value'];
+    }
+  }
+
+  private function _ensureCancellationReasonExists($reason) {
+    if (in_array($reason, $this->_cancellationReasons)) {
+      return;
+    }
+    civicrm_api3('OptionValue', 'Create', [
+      'option_group_id' => 'contract_cancel_reason',
+      'name' => $reason,
+      'label' => $reason,
+      'value' => $reason,
+    ]);
+    $this->_cancellationReasons[] = $reason;
+  }
+
+  private function _getActivityType($name, $label) {
+    $activityType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', $name);
+    if (empty($activityType)) {
+      civicrm_api3('OptionValue', 'create', [
+        'option_group_id' => 'activity_type',
+        'name' => $name,
+        'label' => $label,
+        'is_active' => 1,
+      ]);
+      $activityType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', $name);
+    }
+
+    return $activityType;
+  }
+
+  private function _createActivity($record, $membershipId, $contactId, $activityType, $responseDescription, $time) {
+    $config = CRM_Streetimport_Config::singleton();
+    $activityParams = [
+      'activity_type_id' => $this->_getActivityType($activityType),
+      'subject' => $config->translate('id' . $membershipId . ': ' . $responseDescription),
+      'status_id' => $config->getActivityCompleteStatusId(),
+      'activity_date_time' => date('YmdHis', $time),
+      'target_contact_id' => $contactId,
+      'source_record_id' => $membershipId,
+      'source_contact_id' => (int) $config->getCurrentUserID(),
+      'assignee_contact_id' => (int) $config->getFundraiserContactID(),
+    ];
+    $this->createActivity($activityParams, $record, [$config->getFundraiserContactID()]);
+  }
+
+}

--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
@@ -181,7 +181,7 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
         'id' => $activity['id'],
         'activity_date_time' => date('YmdHis', $time),
         'status_id' => 'scheduled',
-        $cycleDayFieldId => $config->getNextCycleDay(date('Y-m-d H:i:s', $time), $time),
+        $cycleDayFieldId => $config->getNextCycleDay(date('Y-m-d H:i:s', $time), date('Y-m-d H:i:s', $time)),
       ];
       civicrm_api3('Activity', 'Create', $updateParams);
     }
@@ -226,7 +226,7 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
       'action' => 'revive',
       'date' => date('Y-m-d H:i:s', $time),
       'id' => $membershipId,
-      'membership_payment.cycle_day' => $config->getNextCycleDay(date('Y-m-d H:i:s', $time), $time),
+      'membership_payment.cycle_day' => $config->getNextCycleDay(date('Y-m-d H:i:s', $time), date('Y-m-d H:i:s', $time)),
       'medium_id' => $this->_getMediumID(),
     );
     civicrm_api3('Contract', 'Modify', $reviveModification);

--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
@@ -272,9 +272,12 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
     $this->_cancellationReasons[] = $reason;
   }
 
-  private function _getActivityType($name, $label) {
+  private function _getActivityType($name, $label = NULL) {
     $activityType = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', $name);
     if (empty($activityType)) {
+      if (is_null($label)) {
+        $label = $name;
+      }
       civicrm_api3('OptionValue', 'create', [
         'option_group_id' => 'activity_type',
         'name' => $name,

--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
@@ -197,6 +197,7 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
     $updateParams = [
       'id' => $membershipId,
       'start_date' => date('Y-m-d', $time),
+      'skip_handler' => TRUE, // tell de.systopia.contract to ignore this
     ];
     civicrm_api3('Membership', 'Create', $updateParams);
   }

--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
@@ -253,7 +253,10 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
   }
 
   private function _loadCancellationReasons() {
-    $results = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'contract_cancel_reason']);
+    $results = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'contract_cancel_reason',
+      'options' => ['limit' => 0],
+    ]);
     foreach ($results['values'] as $result) {
       $this->_cancellationReasons[] = $result['value'];
     }

--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandlerException.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandlerException.php
@@ -1,0 +1,16 @@
+<?php
+/*-------------------------------------------------------------+
+| Greenpeace Poland StreetImporter Record Handlers             |
+| Copyright (C) 2018 Greenpeace CEE                            |
+| Author: P. Figel (pfigel@greenpeace.org)                     |
++--------------------------------------------------------------*/
+
+/**
+ * Greenpeace Poland Bank Authorization Response Import Exception
+ *
+ * @author Patrick Figel <pfigel@greenpeace.org>
+ * @license AGPL-3.0
+ */
+class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException extends CRM_Exception {
+
+}

--- a/CRM/Streetimport/GPPL/README.md
+++ b/CRM/Streetimport/GPPL/README.md
@@ -1,0 +1,14 @@
+# StreetImport Handlers for Greenpeace Poland
+
+## Handlers
+
+| Name              | Match            | Description                                              |
+|-------------------|------------------|----------------------------------------------------------|
+| BankAuthorization | `AU[YYMMDD].csv` | Processes Authorization Response files from Polish Banks |
+
+## Dependencies
+
+- org.project60.sepa
+- org.project60.banking
+- org.project60.bic
+- de.systopia.contract

--- a/CRM/Streetimport/ImportResult.php
+++ b/CRM/Streetimport/ImportResult.php
@@ -60,7 +60,7 @@ class CRM_Streetimport_ImportResult {
     if ($success) {
       $this->import_success[$record_id] = NULL;
       $this->logMessage(
-        $this->config->translate("Successfully imported record of type")." ". $type,
+        $this->config->translate("Successfully imported record of type")." ". $type . ': ' . $message,
         $record,
         BE_AIVL_STREETIMPORT_DEBUG);
     } else {


### PR DESCRIPTION
This adds a new domain for Greenpeace Poland and a new handler for bank authorization responses.

There's also a minor change for Greenpeace Austria: the "next cycle day" algorithm now uses configurable buffer days from the SEPA extension rather than a hardcoded value of two days.