### PR TITLE
GP-1468: Improve phone number handling

### DIFF
--- a/CRM/Streetimport/GP/Handler/GPRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/GPRecordHandler.php
@@ -836,6 +836,11 @@ abstract class CRM_Streetimport_GP_Handler_GPRecordHandler extends CRM_Streetimp
 
   protected function _normalizePhoneNumber($phone) {
     if (method_exists('CRM_Utils_Normalize', 'normalize_phone')) {
+      if (in_array(substr($phone, 0, 2), ['43', '49'])) {
+        // For numbers starting with AT or DE country code and without a prefix
+        // (i.e. 43680123456), add the prefix so normalize can handle the number
+        $phone = '+' . $phone;
+      }
       $normalized_phone = [
         'phone' => $phone,
         'phone_type_id' => 1

--- a/CRM/Streetimport/GP/Handler/GPRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/GPRecordHandler.php
@@ -833,4 +833,17 @@ abstract class CRM_Streetimport_GP_Handler_GPRecordHandler extends CRM_Streetimp
 
     $this->createActivity($activityParams, $record);
   }
+
+  protected function _normalizePhoneNumber($phone) {
+    if (method_exists('CRM_Utils_Normalize', 'normalize_phone')) {
+      $normalized_phone = [
+        'phone' => $phone,
+        'phone_type_id' => 1
+      ];
+      $normalizer = new CRM_Utils_Normalize();
+      $normalizer->normalize_phone($normalized_phone);
+      return $normalized_phone['phone'];
+    }
+    return $phone;
+  }
 }

--- a/CRM/Streetimport/GP/Handler/StyriaRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/StyriaRecordHandler.php
@@ -74,12 +74,16 @@ class CRM_Streetimport_GP_Handler_StyriaRecordHandler extends CRM_Streetimport_G
       }
     }
 
+    if (array_key_exists('phone', $contact_data)) {
+      $contact_data['phone'] = $this->_normalizePhoneNumber($contact_data['phone']);
+    }
+
     // resolve via XCM
     $contact = civicrm_api3('Contact', 'getorcreate', $contact_data);
 
     // run it again with the second phone number (if there is one)
     if (!empty($record['telefon2'])) {
-      $contact_data['phone'] = trim($record['telefon2']);
+      $contact_data['phone'] = $this->_normalizePhoneNumber(trim($record['telefon2']));
       $contact = civicrm_api3('Contact', 'getorcreate', $contact_data);
     }
     $this->logger->logDebug("Contact [{$contact['id']}] created/identified.", $record);


### PR DESCRIPTION
This normalizes phone numbers when checking whether they already exist and adds phone-based matching for `DDRecordHandler`.

Additionally, this uses `com.cividesk.normalize` to determine the phone type rather than relying on the files to provide the value in the correct column.